### PR TITLE
Added getAttribute() so custom attributes with dynamic index can be pulled from validation language file.

### DIFF
--- a/src/Cohensive/Validation/Validator.php
+++ b/src/Cohensive/Validation/Validator.php
@@ -217,6 +217,21 @@ class Validator extends BaseValidator implements MessageProviderInterface
 	}
 
 	/**
+	 * Get the displayable name of the attribute.
+	 *
+	 * @param  string  $attribute
+	 * @return string
+	 */
+	protected function getAttribute($attribute)
+	{
+		if (strpos($attribute, ':') !== false) {
+			$attribute = preg_replace('/:((\d+)|(\*)):/', ':', $attribute);
+		}
+
+		return parent::getAttribute($attribute);
+	}
+
+	/**
 	 * Replace all error message place-holders with actual values.
 	 *
 	 * @param  string  $message


### PR DESCRIPTION
Added getAttribute() so custom attributes with dynamic index can be pulled from validation language file.

Example:

```
    $data = array('income_sources' => array(
        array(
            'type' => 'employment',
            'employer_name' => '',
            'employer_phone' => 'Bar',
        ),
        array(
            'type' => 'business',
            'business_name' => '',
            'business_nature' => 'Boom',
        ),
    ));

    $rules = array(
        'income_sources:0:employer_name' => 'required',
        'income_sources:1:business_name' => 'required',
    );
```

...and I have the following in my language file (`app/lang/en/validation.php`):

```
    'attributes' => array(
        'income_sources:employer_name' => 'employer name',
        'income_sources:business_name' => 'business name'
    )
```

It will have an error message something like: `The employer name is required.` instead of something like `The income sources:1:employer name is required.`

Sometimes we need to specify index in our data like the above.
