### PR TITLE
Define failures using the iteration index.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
 		"php": ">=5.3.0"
 	},
 	"require-dev": {
-		"illuminate/container": "5.0.*@dev",
-		"illuminate/support": "5.0.*@dev",
-		"illuminate/validation": "5.0.*@dev",
+		"illuminate/container": "5.1.*",
+		"illuminate/support": "5.1.*",
+		"illuminate/validation": "5.1.*",
 		"symfony/http-foundation": "2.7.*",
 		"symfony/translation": "2.7.*",
 		"mockery/mockery": "0.9.*",

--- a/src/Cohensive/Validation/Validator.php
+++ b/src/Cohensive/Validation/Validator.php
@@ -34,11 +34,12 @@ class Validator extends BaseValidator
             // Required to test items even if array is empty.
             $value = empty($value) ? array(null) : $value;
 
-            foreach ($value as $item) {
+            foreach ($value as $index => $item) {
                 $validatable = $this->isValidatable($rule, $attribute, $item);
 
                 if ($validatable and ! $this->$method($attribute, $item, $parameters, $this)) {
-                    $this->addFailure($attribute, $rule, $parameters);
+                    $name = str_replace('*', $index, $attribute);
+                    $this->addFailure($name, $rule, $parameters);
                 }
             }
         } else {


### PR DESCRIPTION
This allows to get which specific item in an array does not match the rules.
A possible usecase is having to display an error message on the correct
nested form field.

At the moment, the failure key is something like "books:*:title". This commit
will change that to, for example, "books:4:title".
